### PR TITLE
Feature/first cover parsing enhancements

### DIFF
--- a/MangaManager.py
+++ b/MangaManager.py
@@ -221,13 +221,19 @@ class SetVolumeCover(tk.Tk):
             """
 
             velog("Selecting covers in opencovers")
-            self.button3_load_images.destroy()
+            self.button3_load_images.grid_remove()
             covers_path_list = filedialog.askopenfiles(initialdir=launch_path,
                                                        title="Open all covers you want to work with:"
                                                        )
             self.licycle = cycle(covers_path_list)
-
-            self.nextelem = next(self.licycle)
+            try:
+                self.nextelem = next(self.licycle)
+            except StopIteration:
+                mb.showwarning("No file selected","No images were selected.")
+                self.image = None
+                self.button3_load_images.grid()
+                logging.critical("No images were selected when asked for")
+                raise
             self.prevelem = None
             self.enableButtons(self.frame_coversetter)
             try:
@@ -438,7 +444,8 @@ class SetVolumeCover(tk.Tk):
 
     def tool_volumesetter(self):
         delog("inside tool-volumesetter")
-
+        self.geometry("500x886")
+        self.resizable(0,0)
         MainLabelVar = tk.StringVar()
         self.title("Volume Setter")
         self.select_tool_old = "Volume Setter"
@@ -752,7 +759,7 @@ class SetVolumeCover(tk.Tk):
             velog("Cleanup: Try to clear treeview")
             if Selected_tool == "Cover":
                 self.treeview1.delete(*self.treeview1.get_children())
-                self.treeview1.grid_forget()
+                # self.treeview1.grid_forget()
             elif Selected_tool == "Volume":
                 self.treeview2.delete(*self.treeview2.get_children())
                 self.treeview2.grid_forget()

--- a/MangaManager.py
+++ b/MangaManager.py
@@ -214,6 +214,7 @@ class SetVolumeCover(tk.Tk):
                 self.do_overwrite_first_label_value.set("Yes")
             # self.do_overwrite_first_label_value.set(f"Replace: {self.do_overwrite_first}")
             print("debugp")
+
         def opencovers():
             """
             Open tki nter.askopenfilename all covers that are going to be placed inside each chapter and loads iter cycle
@@ -408,7 +409,7 @@ class SetVolumeCover(tk.Tk):
 
         self.treeview1.heading('column3', anchor='center', text='Queue')
         self.treeview1.heading('overwrite', anchor='center', text='Overwrite')
-        self.treeview1.grid(column=1, row=0)
+        self.treeview1.grid(column=1, row=0,sticky=tk.N,pady="2 0")
         # Column 1 - Row 1
         self.button4_proceed = tk.Button(self.frame_coversetter)
         self.button4_proceed.configure(text='Proceed')
@@ -421,7 +422,7 @@ class SetVolumeCover(tk.Tk):
         self.progressbar_frame.grid(column=1, row=2, rowspan=2, sticky=tk.W+tk.E,padx=30)
 
         # End frame
-        self.frame_coversetter.configure(height='500', padding='20', width='400')
+        self.frame_coversetter.configure(height=420, padding='20', width='400')
         self.frame_coversetter.grid(column=0, row=0)
 
         # Process first cover


### PR DESCRIPTION
Cover is now the first file that is retrieved from a cbz
Changed buttons to select whether to overwrite/replace current cover or not. Defaults to not overwrite/replace.
The way it works is the same:
- If overwrite is selected: the first file retrieved will be backed up.
- If overwrite is not selected: if it exists any file named `!00000.ext` it will be renamed to `!00001.ext`
In both cases the new cover will be named `!00000.ext`

Added button to select new cover images so there's no need to rerun the script