### PR TITLE
Fix ModuleNotFoundError: No module named 'errors'

### DIFF
--- a/MangaManager/MangaTaggerLib/cbz_handler.py
+++ b/MangaManager/MangaTaggerLib/cbz_handler.py
@@ -5,7 +5,6 @@ import logging
 import io
 from lxml.etree import XMLSyntaxError
 
-#import errors
 from .models import *
 from .errors import *
 from . import ComicInfo

--- a/MangaManager/MangaTaggerLib/cbz_handler.py
+++ b/MangaManager/MangaTaggerLib/cbz_handler.py
@@ -5,9 +5,9 @@ import logging
 import io
 from lxml.etree import XMLSyntaxError
 
-import errors
+#import errors
 from .models import *
-from .errors import NoMetadataFileFound
+from .errors import *
 from . import ComicInfo
 
 logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class ReadComicInfo:
                 comicinfo = ComicInfo.parseString(self.xmlString, silence=print_xml,doRecover=True)
             except Exception as e:
                 logger.error(f"Failed to parse XML:\n{e}\nRecovery attempt failed", exc_info=False)
-                raise errors.CorruptedComicInfo(self.cbz_path)
+                raise CorruptedComicInfo(self.cbz_path)
 
         logger.debug("returning comicinfo")
         return comicinfo


### PR DESCRIPTION
I just found this error when I tried to launch MangaManager.py  
Here's the full traceback:  
```
Traceback (most recent call last):
  File "/home/marc/GitProjects/Manga-Manager/./MangaManager/MangaManager.py", line 7, in <module>
    from MangaTaggerLib import MangaTagger
  File "/home/marc/GitProjects/Manga-Manager/MangaManager/MangaTaggerLib/MangaTagger.py", line 13, in <module>
    from .cbz_handler import ReadComicInfo, WriteComicInfo
  File "/home/marc/GitProjects/Manga-Manager/MangaManager/MangaTaggerLib/cbz_handler.py", line 8, in <module>
    import errors
ModuleNotFoundError: No module named 'errors'
```

I commented the `import errors` line. This fixes the error.
Additionally, I also found that `CorruptedComicInfo` is raised somewhat further down using `errors.CorruptedComicInfo`.  
My linter complained about that, so I changed that as well.