### PR TITLE
File explorer opens last opened folder and critical bug fix

### DIFF
--- a/MangaManager/CoverManagerLib/CoverManager.py
+++ b/MangaManager/CoverManagerLib/CoverManager.py
@@ -279,9 +279,10 @@ class App:
                                       title=title,
                                       filetypes=(("CBZ Files", ".cbz"),)
                                       )
-        selected_parent_folder = os.path.dirname(cbzs_path_list[0].name)
-        if self.last_folder != selected_parent_folder or not self.last_folder:
-            self.last_folder = selected_parent_folder
+        if cbzs_path_list:
+            selected_parent_folder = os.path.dirname(cbzs_path_list[0].name)
+            if self.last_folder != selected_parent_folder or not self.last_folder:
+                self.last_folder = selected_parent_folder
         image = Image.open(image_path)
         image = image.resize((40, 60), Image.ANTIALIAS)
         self.image_in_confirmation = ImageTk.PhotoImage(image)

--- a/MangaManager/CoverManagerLib/CoverManager.py
+++ b/MangaManager/CoverManagerLib/CoverManager.py
@@ -31,6 +31,7 @@ class App:
         self.checkbox2_settings_val = tk.BooleanVar(value=False)
         self.covers_path_in_confirmation = {}
         self._initialized_UI = False
+        self.last_folder = ""
 
     def start_ui(self):
         # build ui
@@ -269,11 +270,18 @@ class App:
                 title = "Select files to overwrite cover"
             else:
                 title = "Select file to apply cover"
-        cbzs_path_list = askopenfiles(parent=self.master, initialdir=self.settings.get("library_folder_path"),
+
+        if not self.last_folder:
+            initial_dir = self.settings.get("library_folder_path")
+        else:
+            initial_dir = self.last_folder
+        cbzs_path_list = askopenfiles(parent=self.master, initialdir=initial_dir,
                                       title=title,
                                       filetypes=(("CBZ Files", ".cbz"),)
                                       )
-
+        selected_parent_folder = os.path.dirname(cbzs_path_list[0].name)
+        if self.last_folder != selected_parent_folder or not self.last_folder:
+            self.last_folder = selected_parent_folder
         image = Image.open(image_path)
         image = image.resize((40, 60), Image.ANTIALIAS)
         self.image_in_confirmation = ImageTk.PhotoImage(image)

--- a/MangaManager/MetadataManagerLib/MetadataManager.py
+++ b/MangaManager/MetadataManagerLib/MetadataManager.py
@@ -973,10 +973,10 @@ class App:
                                       filetypes=(("CBZ Files", ".cbz"),)
                                       # ("Zip files", ".zip"))
                                       )
-
-        selected_parent_folder = os.path.dirname(cbzs_path_list[0].name)
-        if self.last_folder != selected_parent_folder or not self.last_folder:
-            self.last_folder = selected_parent_folder
+        if cbzs_path_list:
+            selected_parent_folder = os.path.dirname(cbzs_path_list[0].name)
+            if self.last_folder != selected_parent_folder or not self.last_folder:
+                self.last_folder = selected_parent_folder
         for file in cbzs_path_list:
             self.selected_filenames.append(file.name)
         self.create_loadedComicInfo_list()

--- a/MangaManager/MetadataManagerLib/MetadataManager.py
+++ b/MangaManager/MetadataManagerLib/MetadataManager.py
@@ -350,7 +350,7 @@ class App:
 
             self.input_1_summary_obj.linked_text_field = self.tkinterscrolledtext_1
         except Exception as e:
-            print(e)
+            pass
         self.input_1_summary_obj.clear()
 
     def _get_widgets_var_zip(self, widgets_variable_list, comicInfoObj: ComicInfo.ComicInfo, widgets_object_list=None):

--- a/MangaManager/MetadataManagerLib/MetadataManager.py
+++ b/MangaManager/MetadataManagerLib/MetadataManager.py
@@ -202,6 +202,7 @@ class App:
         self.spinbox_3_volume_var_isModified = False
         self.disable_metadata_notFound_warning = disable_metadata_notFound_warning
         self.settings = settings
+        self.last_folder = ""
 
         self.warning_metadataNotFound = False
         self.selected_filenames = []
@@ -962,12 +963,21 @@ class App:
         self._clearUI()
 
         self.selected_filenames = list[str]()
-        covers_path_list = askopenfiles(parent=self.master, initialdir=self.settings.get("library_folder_path"),
-                                        title="Select file to apply cover",
-                                        filetypes=(("CBZ Files", ".cbz"),)
-                                        # ("Zip files", ".zip"))
-                                        )
-        for file in covers_path_list:
+        if not self.last_folder:
+            initial_dir = self.settings.get("library_folder_path")
+        else:
+            initial_dir = self.last_folder
+
+        cbzs_path_list = askopenfiles(parent=self.master, initialdir=initial_dir,
+                                      title="Select file to apply cover",
+                                      filetypes=(("CBZ Files", ".cbz"),)
+                                      # ("Zip files", ".zip"))
+                                      )
+
+        selected_parent_folder = os.path.dirname(cbzs_path_list[0].name)
+        if self.last_folder != selected_parent_folder or not self.last_folder:
+            self.last_folder = selected_parent_folder
+        for file in cbzs_path_list:
             self.selected_filenames.append(file.name)
         self.create_loadedComicInfo_list()
         # self._label_28_statusinfo.configure(text="Successfuly loaded")

--- a/MangaManager/MetadataManagerLib/cbz_handler.py
+++ b/MangaManager/MetadataManagerLib/cbz_handler.py
@@ -51,7 +51,7 @@ class ReadComicInfo:
         Reads a cbz o zip file and returns the a ComicInfo class from the ComicInfo.xml file.
         If ComicInfo not present returns none
         """
-        if self.ignore_empty_metadata:
+        if self.ignore_empty_metadata and not self.xmlString:
             logger.debug("returning comicinfo")
             return ComicInfo.ComicInfo()
         print_xml = False if print_xml else True

--- a/MangaManager/VolumeManager/VolumeManager.py
+++ b/MangaManager/VolumeManager/VolumeManager.py
@@ -253,10 +253,10 @@ class App:
         if not self.cbz_files_path_list:
             # self.tool_volumesetter()
             self._label_4_selected_files_val.set(f"Selected 0 files.")
+        else:
             selected_parent_folder = os.path.dirname(self.cbz_files_path_list[0].name)
             if self.last_folder != selected_parent_folder or not self.last_folder:
                 self.last_folder = selected_parent_folder
-        else:
             self._label_4_selected_files_val.set(f"Selected {len(self.cbz_files_path_list)} files")
         # self.enableButtons(self.frame_volumesetter)
 

--- a/MangaManager/VolumeManager/VolumeManager.py
+++ b/MangaManager/VolumeManager/VolumeManager.py
@@ -62,6 +62,7 @@ class App:
         self._spinbox_1_volume_number_val_prev = tk.IntVar(value=-1)
         self._spinbox_1_volume_number_val.trace(mode='w', callback=self.validateIntVar)
         self._initialized_UI = False
+        self.last_folder = ""
 
     def validateIntVar(self, *args):
         try:
@@ -237,10 +238,20 @@ class App:
     def _open_files(self):
 
         logger.debug("inside openfiles")
-        self.cbz_files_path_list = askopenfiles(parent=self.master, initialdir=self.settings.get("library_folder_path"),
+
+        if not self.last_folder:
+            initial_dir = self.settings.get("library_folder_path")
+        else:
+            initial_dir = self.last_folder
+
+        self.cbz_files_path_list = askopenfiles(parent=self.master, initialdir=initial_dir,
                                                 title="Select file to apply cover",
                                                 filetypes=(("CBZ Files", ".cbz"),)
                                                 )
+
+        selected_parent_folder = os.path.dirname(self.cbz_files_path_list[0].name)
+        if self.last_folder != selected_parent_folder or not self.last_folder:
+            self.last_folder = selected_parent_folder
         if not self.cbz_files_path_list:
             # self.tool_volumesetter()
             self._label_4_selected_files_val.set(f"Selected 0 files.")

--- a/MangaManager/VolumeManager/VolumeManager.py
+++ b/MangaManager/VolumeManager/VolumeManager.py
@@ -249,12 +249,13 @@ class App:
                                                 filetypes=(("CBZ Files", ".cbz"),)
                                                 )
 
-        selected_parent_folder = os.path.dirname(self.cbz_files_path_list[0].name)
-        if self.last_folder != selected_parent_folder or not self.last_folder:
-            self.last_folder = selected_parent_folder
+
         if not self.cbz_files_path_list:
             # self.tool_volumesetter()
             self._label_4_selected_files_val.set(f"Selected 0 files.")
+            selected_parent_folder = os.path.dirname(self.cbz_files_path_list[0].name)
+            if self.last_folder != selected_parent_folder or not self.last_folder:
+                self.last_folder = selected_parent_folder
         else:
             self._label_4_selected_files_val.set(f"Selected {len(self.cbz_files_path_list)} files")
         # self.enableButtons(self.frame_volumesetter)

--- a/MangaManager/VolumeManager/VolumeManager.py
+++ b/MangaManager/VolumeManager/VolumeManager.py
@@ -412,7 +412,6 @@ class App:
                     cominfo_app = taggerApp(disable_metadata_notFound_warning=True)
                     cominfo_app.create_loadedComicInfo_list([item.complete_new_path])
                     cominfo_app.entry_Volume_val.set(item.volume)
-                    vol_val = cominfo_app.entry_Volume_val.get()
 
                     cominfo_app.do_save_UI()
                     progressBar.increaseCount()

--- a/MangaManager/settings.json
+++ b/MangaManager/settings.json
@@ -1,4 +1,0 @@
-{
-  "library_folder_path": null,
-  "cover_folder_path": null
-}

--- a/MangaManager/tests/test_Tools.py
+++ b/MangaManager/tests/test_Tools.py
@@ -105,9 +105,11 @@ class CoverManagerTester(unittest.TestCase):
             self.test_files_names.append(os.path.abspath(out_tmp_zipname))
             self.temp_folder = tempfile.mkdtemp()
             print(f"     Creating: {out_tmp_zipname}")  # , self._testMethodName)
+
             with zipfile.ZipFile(out_tmp_zipname, "w") as zf:
                 for i in range(1, 6):
                     zf.writestr(f"{str(i).zfill(3)}.jpg", imgByteArr)
+
         image.save("Test_4_sample_cover.jpg", format=image.format)
         self.test_files_names.append(os.path.abspath("Test_4_sample_cover.jpg"))
         self.sample_cover = os.path.abspath("Test_4_sample_cover.jpg")
@@ -464,6 +466,7 @@ class VolumeManagerTester(unittest.TestCase):
         image = Image.new('RGB', size=(20, 20), color=(255, 73, 95))
         image.format = "JPEG"
         imgByteArr = io.BytesIO()
+        self.random_series_name = f"Test_{random.randint(1, 6000)}"
         image.save(imgByteArr, format=image.format)
         imgByteArr = imgByteArr.getvalue()
         for ai in range(1, 7):  # Create 7 archives.cbz
@@ -471,9 +474,15 @@ class VolumeManagerTester(unittest.TestCase):
             self.test_files_names.append(os.path.abspath(out_tmp_zipname))
             self.temp_folder = tempfile.mkdtemp()
             print(f"     Creating: {out_tmp_zipname}")  # , self._testMethodName)
+            cinfo = ComicInfo.ComicInfo()
+            cinfo.set_Series(self.random_series_name)
+            export_io = io.StringIO()
+            cinfo.export(export_io, 0)
+            _export_io = export_io.getvalue()
             with zipfile.ZipFile(out_tmp_zipname, "w") as zf:
                 for i in range(1, 6):
                     zf.writestr(f"{str(i).zfill(3)}.jpg", imgByteArr)
+                zf.writestr("ComicInfo.xml", _export_io)
         self.initial_dir_count = len(os.listdir(os.getcwd()))
 
     def tearDown(self) -> None:
@@ -540,6 +549,9 @@ class VolumeManagerTester(unittest.TestCase):
         # final_dir_count = len(os.listdir(os.path.dirname(test_path)))
         print(f"Asserting leftover files {initial_dir_count} vs {final_dir_count}")
         self.assertEqual(initial_dir_count, (final_dir_count - 1))
+
+        print("Asserting series name is kept")
+        self.assertEqual(self.random_series_name, app.get_Series())
 
     def test_addVolume_and_rename(self):
 


### PR DESCRIPTION
File Explorer was opening root library folder when it was set in settings. it now opens the last oppened folder. Closes #64
Volume Manager was cleaning comicinfo.xml. Added a test and fixed