### PR TITLE
Global Tag/Genre add/remover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ undo.json
 .pytest_cache
 *.log*
 /.idea/webResources.xml
+/MangaManager/settings.json

--- a/MangaManager/CoverManagerLib/CoverDownloader.py
+++ b/MangaManager/CoverManagerLib/CoverDownloader.py
@@ -58,7 +58,6 @@ class App:
         # self.button_3.configure(text="Open output folder", command=self.open_output_folder)
         # self.button_3.pack(side="top")
 
-
         self._progressbar_frame = tk.Frame(self.frame_3)
         self._progressbar_frame.configure(height='160', width='390')
 
@@ -86,7 +85,8 @@ class App:
 
         elif self._initialized_UI:
             if not output_folder:
-                self.settings["cover_folder_path"] = askdirectory(parent=self.master,initialdir=self.settings.get("cover_folder_path"))
+                self.settings["cover_folder_path"] = askdirectory(parent=self.master,
+                                                                  initialdir=self.settings.get("cover_folder_path"))
             self.label_2.configure(text=str(pathlib.Path(self.settings.get('cover_folder_path'), '<Manga Name>')))
         else:
             self.settings["cover_folder_path"] = ""

--- a/MangaManager/MangaManager.pyw
+++ b/MangaManager/MangaManager.pyw
@@ -81,14 +81,18 @@ parser.add_argument(
 # </Arguments parser>
 
 
-# <Logger>
+# Setup Logger
 logger = logging.getLogger()
 logging.getLogger('PIL').setLevel(logging.WARNING)
 # formatter = logging.Formatter()
 
 PROJECT_PATH = pathlib.Path(__file__).parent
 SETTING_PATH = pathlib.Path(PROJECT_PATH, "settings.json")
-rotating_file_handler = RotatingFileHandler(f"{PROJECT_PATH}/logs/MangaManager.log", maxBytes=5725760,
+LOGS_PATH = pathlib.Path(f"{PROJECT_PATH}/logs/")
+LOGS_PATH.mkdir(parents=True, exist_ok=True)
+LOGFILE_PATH = pathlib.Path(LOGS_PATH, "MangaManager.log")
+
+rotating_file_handler = RotatingFileHandler(LOGFILE_PATH, maxBytes=5725760,
                                             backupCount=2)
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -97,10 +101,10 @@ logging.basicConfig(level=logging.DEBUG,
                     )
 logger.debug('DEBUG LEVEL - MAIN MODULE')
 logger.info('INFO LEVEL - MAIN MODULE')
-# </Logger>
+
+
 images_path = pathlib.Path(PROJECT_PATH, "Icons")
 tools = [CoverManager, MetadataManager, VolumeManager, epub2cbz, WebpConverter]
-
 
 
 def load_settings():

--- a/MangaManager/MetadataManagerLib/MetadataManager.py
+++ b/MangaManager/MetadataManagerLib/MetadataManager.py
@@ -251,6 +251,12 @@ class App:
         self.entry_Year_val = tk.IntVar(value=-1, name="Year")
         self.entry_Month_val = tk.IntVar(value=-1, name="Month")
         self.entry_Day_val = tk.IntVar(value=-1, name="Day")
+
+        self.global_genres_add_val = tk.StringVar(value='')
+        self.global_genres_remove_val = tk.StringVar(value='')
+        self.global_tags_add_val = tk.StringVar(value='')
+        self.global_tags_remove_val = tk.StringVar(value='')
+
         try:
             self.input_1_summary_obj.linked_text_field = self.tkinterscrolledtext_1
         except:
@@ -499,26 +505,54 @@ class App:
         self._entry_Notes1.bind('<Double-Button-1>', self.makeEditable, add='')
         self._entry_Notes1.bind('<FocusOut>', onFocusOut, add='')
         self._entry_Notes1.bind('<Return>', makeReadOnly, add='')
+
         self._label_24 = tk.Label(self.frame_2)
         self._label_24.configure(text='Genre')
         self._label_24.pack(side='top')
-        self._entry_Genre1 = ttk.Combobox(self.frame_2)
+        self.frame_5 = tk.Frame(self.frame_2)
+        self._entry_Genre1 = ttk.Combobox(self.frame_5)
+
         self._entry_Genre1.configure(textvariable=self.entry_Genre_val)
-        self._entry_Genre1.pack(fill='both', side='top')
-        self._entry_Genre1.bind('<Button-1>', makeFocused, add='')
-        self._entry_Genre1.bind('<Double-Button-1>', self.makeEditable, add='')
-        self._entry_Genre1.bind('<FocusOut>', onFocusOut, add='')
-        self._entry_Genre1.bind('<Return>', makeReadOnly, add='')
+        self._entry_Genre1.pack(fill='both', pady='2', side='top')
+        self._label_52 = tk.Label(self.frame_5)
+        self._label_52.configure(text='Global add genres')
+        self._label_52.pack(side='left')
+        self._entry_Genres_Global_Add = tk.Entry(self.frame_5)
+
+        self._entry_Genres_Global_Add.configure(textvariable=self.global_genres_add_val)
+        self._entry_Genres_Global_Add.pack(expand='true', fill='x', padx='5', side='left')
+        self._entry_Genres_Global_Remove = tk.Entry(self.frame_5)
+
+        self._entry_Genres_Global_Remove.configure(textvariable=self.global_genres_remove_val)
+        self._entry_Genres_Global_Remove.pack(expand='true', fill='x', padx='5', side='right')
+        self.label_51 = tk.Label(self.frame_5)
+        self.label_51.configure(text='Global remove genres')
+        self.label_51.pack(side='right')
+        self.frame_5.pack(anchor='center', expand='true', fill='both', side='top')
         self._label_25 = tk.Label(self.frame_2)
-        self._label_25.configure(text='Tags')
+        self._label_25.configure(pady='5', text='Tags')
         self._label_25.pack(side='top')
-        self._entry_Tags1 = ttk.Combobox(self.frame_2)
+        self._frame_6_Tags = tk.Frame(self.frame_2)
+        self._entry_Tags1 = ttk.Combobox(self._frame_6_Tags)
+
         self._entry_Tags1.configure(textvariable=self.entry_Tags_val)
-        self._entry_Tags1.pack(fill='both', side='top')
-        self._entry_Tags1.bind('<Button-1>', makeFocused, add='')
-        self._entry_Tags1.bind('<Double-Button-1>', self.makeEditable, add='')
-        self._entry_Tags1.bind('<FocusOut>', onFocusOut, add='')
-        self._entry_Tags1.bind('<Return>', makeReadOnly, add='')
+        self._entry_Tags1.pack(expand='true', fill='both', pady='2', side='top')
+        self._label_50 = tk.Label(self._frame_6_Tags)
+        self._label_50.configure(text='Global add tags')
+        self._label_50.pack(side='left')
+        self._entry_Tags_Global_Add = tk.Entry(self._frame_6_Tags)
+
+        self._entry_Tags_Global_Add.configure(textvariable=self.global_tags_add_val)
+        self._entry_Tags_Global_Add.pack(expand='true', fill='x', padx='5', side='left')
+        self._entry_Tags_Global_Remove = tk.Entry(self._frame_6_Tags)
+
+        self._entry_Tags_Global_Remove.configure(textvariable=self.global_tags_remove_val)
+        self._entry_Tags_Global_Remove.pack(expand='true', fill='x', padx='5', side='right')
+        self._label_53 = tk.Label(self._frame_6_Tags)
+        self._label_53.configure(text='Global remove tags')
+        self._label_53.pack(side='right')
+        self._frame_6_Tags.pack(anchor='center', expand='true', fill='both', side='top')
+
         self._label_26 = tk.Label(self.frame_2)
         self._label_26.configure(text='Web')
         self._label_26.pack(side='top')
@@ -1236,6 +1270,45 @@ class App:
                 # Else modify field with whatever is on the stringvar/intvar
                 else:
                     comicinfo_atr_set(widgetvar.get())
+            tags_list = comicObj.comicInfoObj.get_Tags()
+            if tags_list:
+                tags_list = tags_list.split(",")
+            genres_list = comicObj.comicInfoObj.get_Genre()
+            if genres_list:
+                genres_list = genres_list.split(",")
+            append_tags = self.global_tags_add_val.get()
+            if append_tags:
+                append_tags = append_tags.split(",")
+            remove_tags = self.global_tags_remove_val.get()
+            if remove_tags:
+                remove_tags = remove_tags.split(",")
+            append_genres = self.global_genres_add_val.get()
+            if append_genres:
+                append_genres = append_genres.split(",")
+            remove_genres = self.global_genres_remove_val.get()
+            if remove_genres:
+                remove_genres = remove_genres.split(",")
+            # Global tags/genres
+            if append_tags:
+                for tag in append_tags:
+                    if tag not in tags_list:
+                        tags_list.append(tag)
+            if remove_tags:
+                for tag in remove_tags:
+                    if tag in tags_list:
+                        tags_list.remove(tag)
+
+            if append_genres:
+                for genre in append_genres:
+                    if genre not in genres_list:
+                        genres_list.append(genre)
+            if remove_genres:
+                for genre in remove_genres:
+                    if genre in genres_list:
+                        genres_list.remove(genre)
+
+            comicObj.comicInfoObj.set_Tags(",".join(tags_list))
+            comicObj.comicInfoObj.set_Genre(",".join(genres_list))
 
             modified_loadedComicInfo, keep_original_value = comicObj, keep_original_value
             modified_loadedComicInfo_list.append(modified_loadedComicInfo)

--- a/MangaManager/MetadataManagerLib/MetadataManager_UI.ui
+++ b/MangaManager/MetadataManagerLib/MetadataManager_UI.ui
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface version="1.2">
   <object class="tk.Frame" id="frame_1">
-    <property name="height">600</property>
-    <property name="width">200</property>
+    <property name="height">200</property>
+    <property name="width">600</property>
     <layout manager="pack">
       <property name="anchor">center</property>
       <property name="expand">true</property>
@@ -278,6 +278,7 @@
                         </child>
                         <child>
                           <object class="tk.Label" id="_label_24">
+                            <property name="pady">5</property>
                             <property name="text" translatable="yes">Genre</property>
                             <layout manager="pack">
                               <property name="side">top</property>
@@ -285,20 +286,70 @@
                           </object>
                         </child>
                         <child>
-                          <object class="ttk.Combobox" id="_entry_Genre1">
-                            <property name="textvariable">string:entry_Genre_val</property>
-                            <bind sequence="&lt;Button-1&gt;" handler="makeFocused" add=""/>
-                            <bind sequence="&lt;Double-Button-1&gt;" handler="makeEditable" add=""/>
-                            <bind sequence="&lt;FocusOut&gt;" handler="onFocusOut" add=""/>
-                            <bind sequence="&lt;Return&gt;" handler="makeReadOnly" add=""/>
+                          <object class="tk.Frame" id="frame_5">
                             <layout manager="pack">
+                              <property name="anchor">center</property>
+                              <property name="expand">true</property>
                               <property name="fill">both</property>
                               <property name="side">top</property>
                             </layout>
+                            <child>
+                              <object class="ttk.Combobox" id="_entry_Genre1">
+                                <property name="textvariable">string:entry_Genre_val</property>
+                                <bind sequence="&lt;Button-1&gt;" handler="makeFocused" add=""/>
+                                <bind sequence="&lt;Double-Button-1&gt;" handler="makeEditable" add=""/>
+                                <bind sequence="&lt;FocusOut&gt;" handler="onFocusOut" add=""/>
+                                <bind sequence="&lt;Return&gt;" handler="makeReadOnly" add=""/>
+                                <layout manager="pack">
+                                  <property name="fill">both</property>
+                                  <property name="pady">2</property>
+                                  <property name="side">top</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="tk.Label" id="_label_52">
+                                <property name="text" translatable="yes">Global add genres</property>
+                                <layout manager="pack">
+                                  <property name="side">left</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="tk.Entry" id="_entry_Genres_Global_Add">
+                                <property name="textvariable">string:global_genres_add_val</property>
+                                <layout manager="pack">
+                                  <property name="expand">true</property>
+                                  <property name="fill">x</property>
+                                  <property name="padx">5</property>
+                                  <property name="side">left</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="tk.Entry" id="_entry_Genres_Global_Remove">
+                                <property name="textvariable">string:global_genres_remove_val</property>
+                                <layout manager="pack">
+                                  <property name="expand">true</property>
+                                  <property name="fill">x</property>
+                                  <property name="padx">5</property>
+                                  <property name="side">right</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="tk.Label" id="label_51">
+                                <property name="text" translatable="yes">Global remove genres</property>
+                                <layout manager="pack">
+                                  <property name="side">right</property>
+                                </layout>
+                              </object>
+                            </child>
                           </object>
                         </child>
                         <child>
                           <object class="tk.Label" id="_label_25">
+                            <property name="pady">5</property>
                             <property name="text" translatable="yes">Tags</property>
                             <layout manager="pack">
                               <property name="side">top</property>
@@ -306,16 +357,66 @@
                           </object>
                         </child>
                         <child>
-                          <object class="ttk.Combobox" id="_entry_Tags1">
-                            <property name="textvariable">string:entry_Tags_val</property>
-                            <bind sequence="&lt;Button-1&gt;" handler="makeFocused" add=""/>
-                            <bind sequence="&lt;Double-Button-1&gt;" handler="makeEditable" add=""/>
-                            <bind sequence="&lt;FocusOut&gt;" handler="onFocusOut" add=""/>
-                            <bind sequence="&lt;Return&gt;" handler="makeReadOnly" add=""/>
+                          <object class="tk.Frame" id="_frame_6_Tags">
                             <layout manager="pack">
+                              <property name="anchor">center</property>
+                              <property name="expand">true</property>
                               <property name="fill">both</property>
                               <property name="side">top</property>
                             </layout>
+                            <child>
+                              <object class="ttk.Combobox" id="_entry_Tags1">
+                                <property name="textvariable">string:entry_Tags_val</property>
+                                <bind sequence="&lt;Button-1&gt;" handler="makeFocused" add=""/>
+                                <bind sequence="&lt;Double-Button-1&gt;" handler="makeEditable" add=""/>
+                                <bind sequence="&lt;FocusOut&gt;" handler="onFocusOut" add=""/>
+                                <bind sequence="&lt;Return&gt;" handler="makeReadOnly" add=""/>
+                                <layout manager="pack">
+                                  <property name="expand">true</property>
+                                  <property name="fill">both</property>
+                                  <property name="pady">2</property>
+                                  <property name="side">top</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="tk.Label" id="_label_50">
+                                <property name="text" translatable="yes">Global add tags</property>
+                                <layout manager="pack">
+                                  <property name="side">left</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="tk.Entry" id="_entry_Tags_Global_Add">
+                                <property name="textvariable">string:global_tags_add_val</property>
+                                <layout manager="pack">
+                                  <property name="expand">true</property>
+                                  <property name="fill">x</property>
+                                  <property name="padx">5</property>
+                                  <property name="side">left</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="tk.Entry" id="_entry_Tags_Global_Remove">
+                                <property name="textvariable">string:global_tags_remove_val</property>
+                                <layout manager="pack">
+                                  <property name="expand">true</property>
+                                  <property name="fill">x</property>
+                                  <property name="padx">5</property>
+                                  <property name="side">right</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="tk.Label" id="_label_53">
+                                <property name="text" translatable="yes">Global remove tags</property>
+                                <layout manager="pack">
+                                  <property name="side">right</property>
+                                </layout>
+                              </object>
+                            </child>
                           </object>
                         </child>
                         <child>

--- a/MangaManager/tests/test_MetadataManager.py
+++ b/MangaManager/tests/test_MetadataManager.py
@@ -69,7 +69,9 @@ class ComicInfoClassTester(unittest.TestCase):
         # @classmethod
         # def list(cls):
         #     return list(map(lambda c: c.value, cls))
+        print("Assert AgeRating has list method:")
         self.assertTrue(ComicInfo.AgeRating.list())
+        print("Assert ComicPageType has list method:")
         self.assertTrue(ComicInfo.ComicPageType.list())
         ComicInfo.parseString(comicinfo_23, silence=True, print_warnings=False, doRecover=True)
 
@@ -279,3 +281,67 @@ class MetadataManagerTester(unittest.TestCase):
                         print(
                             f"    ┣━━	Assert {str(widget_var)}:\n    ┃   ┗━━ '{widget_var.get()}' vs '{int(random_value)}'\n    ┃")
                         self.assertEqual(widget_var.get(), int(random_value))
+
+
+class GlobalTagsGenres(unittest.TestCase):
+    def setUp(self) -> None:
+        self.loadedComicInfo_list = []
+        print("\n", self._testMethodName)
+        print("Setup:")
+        self.genres = ["Genre_1, Genre_2, Genre_3, Common_genre_4",
+                       "Genre_4, Genre_5, Genre_6",
+                       "Genre_7, Genre_8, Genre_9, Common_genre_4",
+                       "Genre_10, Genre_11, Genre_12",
+                       "Genre_13, Genre_14, Genre_15, Common_genre_4"]
+        self.tags = ["Tag_1, Tag_2, Tag_3",
+                     "Tag_4, Tag_5, Tag_6, Common_tag_4",
+                     "Tag_7, Tag_8, Tag_9",
+                     "Tag_10, Tag_11, Tag_12, Common_tag_4",
+                     "Tag_13, Tag_14, Tag_15"]
+
+        self.common_tag = "Common_tag_1, Common_tag_2, Common_tag_3"
+        self.common_genre = "Common_genre_1, Common_genre_2, Common_genre_3"
+
+        for ai in range(3):
+            cinfo = ComicInfo.ComicInfo()
+            cinfo.set_Genre(self.genres[ai])
+            cinfo.set_Tags(self.tags[ai])
+            self.loadedComicInfo_list.append(LoadedComicInfo("", cinfo))
+
+            self.initial_dir_count = len(os.listdir(os.getcwd()))
+
+    #
+    def test_Append_Global(self):
+        root = tk.Tk()
+        app: MetadataManager.App = MetadataManager.App(root)
+        app.loadedComicInfo_list = self.loadedComicInfo_list
+
+        app.global_tags_add_val.set(self.common_tag)
+        app.global_genres_add_val.set(self.common_genre)
+        app._parseUI_toComicInfo()
+
+        print("Assert that all common tags are present in all the loaded cinfo")
+        for loadedCinfo in app.loadedComicInfo_list:
+            for tag in self.common_tag.split(","):
+                self.assertTrue(tag in loadedCinfo.comicInfoObj.get_Tags())
+            for genre in self.common_genre.split(","):
+                self.assertTrue(genre in loadedCinfo.comicInfoObj.get_Genre())
+
+    def test_Remove_Global(self):
+        root = tk.Tk()
+        app: MetadataManager.App = MetadataManager.App(root)
+        app.loadedComicInfo_list = self.loadedComicInfo_list
+
+        # app.global_tags_add_val.set(self.common_tag)
+        # app.global_genres_add_val.set(self.common_genre)
+        # app._parseUI_toComicInfo()
+        app.global_tags_remove_val.set("Common_genre_4, Genre_1, Genre_8")
+        app.global_genres_remove_val.set("Common_tag_4, Tag_1, Tag_8")
+        app._parseUI_toComicInfo()
+
+        print("Assert that all common tags are removed from all the loaded cinfo")
+        for loadedCinfo in app.loadedComicInfo_list:
+            for tag in "Common_genre_4, Genre_1, Genre_8".split(","):
+                self.assertFalse(tag in loadedCinfo.comicInfoObj.get_Tags())
+            for genre in "Common_tag_4, Tag_1, Tag_8".split(","):
+                self.assertFalse(genre in loadedCinfo.comicInfoObj.get_Genre())


### PR DESCRIPTION
New fields in metadata manager to add or remove tags globally to all the selected files while keeping their own tags or genres even if they differ.