### PR TITLE
Slight Optimizations reading metadata

### DIFF
--- a/.idea/Manga-Manager.iml
+++ b/.idea/Manga-Manager.iml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/MangaManager" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/MangaManager/tests" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/MangaManager/Templates" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/MangaManager/MetadataManagerLib/cbz_handler.py
+++ b/MangaManager/MetadataManagerLib/cbz_handler.py
@@ -61,11 +61,12 @@ class ReadComicInfo:
                 archive.close()
             except KeyError as e:
                 archive.close()
-                if str(e) == "\"There is no item named 'ComicInfo.xml' in the archive\"":
-                    logger.error(f"There is no item named 'ComicInfo.xml' in the archive '{cbz_path}'")
-                    raise NoMetadataFileFound(cbz_path)
-                else:
-                    raise e
+                if not ignore_empty_metadata:
+                    if str(e) == "\"There is no item named 'ComicInfo.xml' in the archive\"":
+                        logger.error(f"There is no item named 'ComicInfo.xml' in the archive '{cbz_path}'")
+                        raise NoMetadataFileFound(cbz_path)
+                    else:
+                        raise e
         else:
             self.xmlString = comicinfo_xml
         logger.debug("ReadComicInfo: Reading XML done")

--- a/MangaManager/MetadataManagerLib/cbz_handler.py
+++ b/MangaManager/MetadataManagerLib/cbz_handler.py
@@ -17,6 +17,19 @@ else:
 
 logger = logging.getLogger(__name__)
 
+class ReadMetadata:
+    def __init__(self, cbz_path):
+        """
+        Reads comicinfo without extracting the zip
+        """
+
+
+    def to_ComicInfo(self) -> "ComicInfo.ComicInfo":
+        metadata = ReadComicInfo("", self.metadata).to_ComicInfo()
+        archive.close()
+        logger.debug("Successfully read metadata")
+        return metadata
+
 
 def is_folder(name: str, folders_list):
     if name.split("/")[0] + "/" in folders_list:
@@ -31,17 +44,28 @@ class ReadComicInfo:
         self.xmlString = ""
         self.ignore_empty_metadata = ignore_empty_metadata
         self.total_files = 0
-        comicinfo_xml_exists = False
         if not comicinfo_xml:
-            with zipfile.ZipFile(self.cbz_path, 'r') as zin:
-                self.total_files = len(zin.infolist())
-                for file in zin.infolist():
-                    if file.filename == "ComicInfo.xml":
-                        comicinfo_xml_exists = True
-                        with zin.open(file) as infile:
-                            self.xmlString = infile.read()
-                if not comicinfo_xml_exists and not ignore_empty_metadata:
-                    raise NoMetadataFileFound(self.cbz_path)
+            # with zipfile.ZipFile(self.cbz_path, 'r') as zin:
+            #     self.total_files = len(zin.infolist())
+            #     for file in zin.infolist():
+            #         if file.filename == "ComicInfo.xml":
+            #             comicinfo_xml_exists = True
+            #             with zin.open(file) as infile:
+            #                 self.xmlString = infile.read()
+            #     if not comicinfo_xml_exists and not ignore_empty_metadata:
+            #         raise NoMetadataFileFound(self.cbz_path)
+
+            archive = zipfile.ZipFile(cbz_path, 'r')
+            try:
+                self.xmlString = archive.read('ComicInfo.xml').decode('utf-8')
+                archive.close()
+            except KeyError as e:
+                archive.close()
+                if str(e) == "\"There is no item named 'ComicInfo.xml' in the archive\"":
+                    logger.error(f"There is no item named 'ComicInfo.xml' in the archive '{cbz_path}'")
+                    raise NoMetadataFileFound(cbz_path)
+                else:
+                    raise e
         else:
             self.xmlString = comicinfo_xml
         logger.debug("ReadComicInfo: Reading XML done")
@@ -68,10 +92,8 @@ class ReadComicInfo:
         logger.debug("returning comicinfo")
         return comicinfo
 
-
-
     def to_String(self) -> str:
-        return self.xmlString.decode('utf-8')
+        return self.xmlString
 
 
 class WriteComicInfo:

--- a/MangaManager/MetadataManagerLib/errors.py
+++ b/MangaManager/MetadataManagerLib/errors.py
@@ -2,16 +2,14 @@ class NoMetadataFileFound(Exception):
     """
     Exception raised when not enough data is given to create a Metadata object.
     """
-
     def __init__(self, cbz_path):
-        super().__init__(f'ComicInfo.xml not found inside {cbz_path}')
+        super().__init__(f"ComicInfo.xml not found inside '{cbz_path}'")
 
 
 class CorruptedComicInfo(Exception):
     """
     Exception raised when the attempt to recover comicinfo file fails..
     """
-
     def __init__(self, cbz_path):
         super().__init__(f'Failed to recover ComicInfo.xml data in {cbz_path}')
 


### PR DESCRIPTION
Directly opens the file or excepts if its not found instead of iterating content of files until ComicInfo.xml is found.